### PR TITLE
[BUG FIX] Fix AppBar and Types component to use dynamic text color back or white

### DIFF
--- a/app/src/main/java/es/infolojo/infolojopokedex/ui/components/StatsRecyclerComponent.kt
+++ b/app/src/main/java/es/infolojo/infolojopokedex/ui/components/StatsRecyclerComponent.kt
@@ -1,4 +1,4 @@
-package es.infolojo.infolojopokedex.ui.screens
+package es.infolojo.infolojopokedex.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/app/src/main/java/es/infolojo/infolojopokedex/ui/components/TypesRow.kt
+++ b/app/src/main/java/es/infolojo/infolojopokedex/ui/components/TypesRow.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import es.infolojo.infolojopokedex.data.common.POKEMON_TYPE_COLOR
 import es.infolojo.infolojopokedex.ui.theme.InfolojoPokedexTheme
 import es.infolojo.infolojopokedex.ui.vo.PokemonTypeVO
+import es.infolojo.infolojopokedex.utils.ThemeHelper.findCorrectTextColor
 
 private const val TYPES_TITLE = "Types"
 
@@ -28,14 +30,17 @@ fun TypesRow(
         Text(text = TYPES_TITLE, style = titleStyle)
         Row {
             types.map {
-                Column(modifier = Modifier.padding(end = 8.dp, top = 4.dp)) {
+                Column(
+                    modifier = Modifier.padding(end = 8.dp, top = 4.dp)
+                        .background(
+                            color = it.color.colorValue,
+                            shape = RoundedCornerShape(25)
+                        )
+                ) {
                     Text(
                         text = it.name,
-                        modifier = Modifier
-                            .background(
-                                color = it.color.colorValue
-                            )
-                            .padding(start = 4.dp, end = 4.dp, bottom = 4.dp)
+                        color = findCorrectTextColor(color = it.color.colorValue),
+                        modifier = Modifier.padding(start = 4.dp, end = 4.dp, bottom = 4.dp)
                     )
                 }
             }

--- a/app/src/main/java/es/infolojo/infolojopokedex/ui/components/appBar/AppBar.kt
+++ b/app/src/main/java/es/infolojo/infolojopokedex/ui/components/appBar/AppBar.kt
@@ -56,7 +56,11 @@ fun AppBar(
         },
         navigationIcon = {
             IconButton(onClick = { onIconClick() }) {
-                Icon(imageVector = startIcon , contentDescription = "")
+                Icon(
+                    imageVector = startIcon,
+                    contentDescription = "",
+                    tint = textColor
+                )
             }
         },
         actions = {

--- a/app/src/main/java/es/infolojo/infolojopokedex/ui/screens/PokemonDetailScreen.kt
+++ b/app/src/main/java/es/infolojo/infolojopokedex/ui/screens/PokemonDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import es.infolojo.infolojopokedex.data.common.POKEMON_TYPE_COLOR
 import es.infolojo.infolojopokedex.ui.components.Spinner
+import es.infolojo.infolojopokedex.ui.components.StatsRecyclerComponent
 import es.infolojo.infolojopokedex.ui.components.TypesRow
 import es.infolojo.infolojopokedex.ui.components.appBar.AppBar
 import es.infolojo.infolojopokedex.ui.components.appBar.IconsManagerVO

--- a/app/src/main/java/es/infolojo/infolojopokedex/utils/ThemeHelper/ThemeHelper.kt
+++ b/app/src/main/java/es/infolojo/infolojopokedex/utils/ThemeHelper/ThemeHelper.kt
@@ -40,5 +40,5 @@ fun isDarkColor(color: Color): Boolean {
     // These values are the definition of luminance for digital formats: https://en.wikipedia.org/wiki/Luma_%28video%29
     val darkness =
         1 - (0.299 * color.red + 0.587 * color.green + 0.114 * color.blue)
-    return darkness >= 0.5
+    return darkness >= 0.4
 }


### PR DESCRIPTION
 Fix AppBar and Types component to use dynamic text color back or white by reducing darkness check in ThemeHelper by checking if color is .4 instead of .5 and add functionallity to TypesRow component, updated also component to use border corners instead of rectangles.

***Before***

<img width="384" alt="image" src="https://github.com/ajloinformatico/InfolojoPokedex/assets/57002879/ea21edfd-7926-4ea4-b560-e06d98c0c81b">

<img width="375" alt="image" src="https://github.com/ajloinformatico/InfolojoPokedex/assets/57002879/dec184c0-18d0-42fb-94dc-bd2d78b2f084">


***After***

<img width="370" alt="image" src="https://github.com/ajloinformatico/InfolojoPokedex/assets/57002879/81a983d9-a291-45d7-86fa-0f5f00e082a4">

<img width="366" alt="image" src="https://github.com/ajloinformatico/InfolojoPokedex/assets/57002879/ac981bb4-31a1-4179-8b09-fa41c3052c44">
